### PR TITLE
Re-add support for jitpack publishing in gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id 'maven-publish'
 }
 
 def gitBranch() {
@@ -64,5 +65,13 @@ processResources {
     from("$projectDir") {
         include("LICENSE")
         into("")
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
     }
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
Hi, Jwkerr

I've been trying to add the latest version of Quarters to my `pom.xml` file, but I noticed that the [builds were failing](https://jitpack.io/com/github/jwkerr/Quarters/961d295961/build.log) on jitpack. After some investigation, it looks like JitPack publishing was accidentally removed when the project was migrated from Maven to Gradle.

I have added the `maven-publish` plugin to the gradle file and have also included a `jitpack.yml` to tell it to use java 17.

Successful build -> https://jitpack.io/com/github/kingplunky/Quarters/719e22e07e/build.log