### PR TITLE
Optimise PlayerMoveEvent listener

### DIFF
--- a/src/main/java/au/lupine/quarters/listener/QuarterEntryListener.java
+++ b/src/main/java/au/lupine/quarters/listener/QuarterEntryListener.java
@@ -36,6 +36,8 @@ public class QuarterEntryListener implements Listener {
 
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
+        if (!event.hasChangedBlock()) return;
+
         Player player = event.getPlayer();
 
         Resident resident = TownyAPI.getInstance().getResident(player);


### PR DESCRIPTION
We can significantly reduce the number of checks made by ignoring move events in which the player did not change blocks (e.g. moving within the same block or rotating their head), as such movements will not result in the player changing quarters.