### PR TITLE
Add QuarterDeleteEvent

### DIFF
--- a/src/main/java/au/lupine/quarters/api/event/CancellableQuarterDeleteEvent.java
+++ b/src/main/java/au/lupine/quarters/api/event/CancellableQuarterDeleteEvent.java
@@ -24,24 +24,21 @@ public class CancellableQuarterDeleteEvent extends CancellableQuartersEvent {
     /**
      * @return The deleted quarter.
      */
-    @NotNull
-    public Quarter getQuarter() {
+    public @NotNull Quarter getQuarter() {
         return quarter;
     }
 
     /**
      * @return The {@link Cause cause} of the quarter's deletion.
      */
-    @NotNull
-    public Cause getCause() {
+    public @NotNull Cause getCause() {
         return cause;
     }
 
     /**
      * @return The {@link CommandSender sender} who caused the deletion
      */
-    @Nullable
-    public CommandSender getSender() {
+    public @Nullable CommandSender getSender() {
         return sender;
     }
 

--- a/src/main/java/au/lupine/quarters/api/event/CancellableQuarterDeleteEvent.java
+++ b/src/main/java/au/lupine/quarters/api/event/CancellableQuarterDeleteEvent.java
@@ -2,6 +2,7 @@ package au.lupine.quarters.api.event;
 
 import au.lupine.quarters.object.base.CancellableQuartersEvent;
 import au.lupine.quarters.object.entity.Quarter;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -16,6 +17,7 @@ public class CancellableQuarterDeleteEvent extends CancellableQuartersEvent {
     private final CommandSender sender;
 
     public CancellableQuarterDeleteEvent(@NotNull Quarter quarter, @NotNull Cause cause, @Nullable CommandSender sender) {
+        super(!Bukkit.isPrimaryThread());
         this.quarter = quarter;
         this.cause = cause;
         this.sender = sender;

--- a/src/main/java/au/lupine/quarters/api/event/CancellableQuarterDeleteEvent.java
+++ b/src/main/java/au/lupine/quarters/api/event/CancellableQuarterDeleteEvent.java
@@ -4,18 +4,18 @@ import au.lupine.quarters.object.base.CancellableQuartersEvent;
 import au.lupine.quarters.object.entity.Quarter;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class QuarterDeleteEvent extends CancellableQuartersEvent {
+public class CancellableQuarterDeleteEvent extends CancellableQuartersEvent {
+
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final Quarter quarter;
     private final Cause cause;
     private final CommandSender sender;
 
-    public QuarterDeleteEvent(@NotNull Quarter quarter, @NotNull Cause cause, @Nullable CommandSender sender) {
+    public CancellableQuarterDeleteEvent(@NotNull Quarter quarter, @NotNull Cause cause, @Nullable CommandSender sender) {
         this.quarter = quarter;
         this.cause = cause;
         this.sender = sender;
@@ -38,7 +38,7 @@ public class QuarterDeleteEvent extends CancellableQuartersEvent {
     }
 
     /**
-     * @return The {@link CommandSender sender} who caused the deletion.
+     * @return The {@link CommandSender sender} who caused the deletion
      */
     @Nullable
     public CommandSender getSender() {
@@ -47,28 +47,30 @@ public class QuarterDeleteEvent extends CancellableQuartersEvent {
 
     public enum Cause {
         UNKNOWN,
-        /**
-         * The quarter was deleted for containing Wilderness.
-         */
-        CONTAINS_WILDERNESS,
-        /**
-         * The quarter was deleted because a player used /quarters delete.
-         */
-        COMMAND,
-        /**
-         * The quarter was deleted because an admin used /quartersadmin delete.
-         */
-        ADMIN_COMMAND;
 
-        @ApiStatus.Internal
-        public boolean ignoresCancellation() {
-            return this == CONTAINS_WILDERNESS;
-        }
+        /**
+         * The quarter was deleted because a player used /quarters delete
+         */
+        DELETE_COMMAND,
+
+        /**
+         * The quarter was deleted because a player used /quarters delete all
+         */
+        DELETE_ALL_COMMAND,
+
+        /**
+         * The quarter was deleted because a player used /quarters delete plot
+         */
+        DELETE_PLOT_COMMAND,
+
+        /**
+         * The quarter was deleted because an admin used /quartersadmin delete
+         */
+        ADMIN_DELETE_COMMAND
     }
 
-    @NotNull
     @Override
-    public HandlerList getHandlers() {
+    public @NotNull HandlerList getHandlers() {
         return HANDLER_LIST;
     }
 

--- a/src/main/java/au/lupine/quarters/api/event/PreBuildGsonEvent.java
+++ b/src/main/java/au/lupine/quarters/api/event/PreBuildGsonEvent.java
@@ -2,8 +2,12 @@ package au.lupine.quarters.api.event;
 
 import au.lupine.quarters.object.base.QuartersEvent;
 import com.google.gson.GsonBuilder;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class PreBuildGsonEvent extends QuartersEvent {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final GsonBuilder builder;
 
@@ -14,5 +18,14 @@ public class PreBuildGsonEvent extends QuartersEvent {
 
     public GsonBuilder getBuilder() {
         return builder;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
     }
 }

--- a/src/main/java/au/lupine/quarters/api/event/QuarterDeleteEvent.java
+++ b/src/main/java/au/lupine/quarters/api/event/QuarterDeleteEvent.java
@@ -1,0 +1,38 @@
+package au.lupine.quarters.api.event;
+
+import au.lupine.quarters.object.base.QuartersEvent;
+import au.lupine.quarters.object.entity.Quarter;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class QuarterDeleteEvent extends QuartersEvent {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Quarter quarter;
+    private final CommandSender sender;
+
+    public QuarterDeleteEvent(@NotNull Quarter quarter, @Nullable CommandSender sender) {
+        this.quarter = quarter;
+        this.sender = sender;
+    }
+
+    public @NotNull Quarter getQuarter() {
+        return quarter;
+    }
+
+    public @Nullable CommandSender getSender() {
+        return sender;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/au/lupine/quarters/api/event/QuarterDeleteEvent.java
+++ b/src/main/java/au/lupine/quarters/api/event/QuarterDeleteEvent.java
@@ -2,6 +2,7 @@ package au.lupine.quarters.api.event;
 
 import au.lupine.quarters.object.base.QuartersEvent;
 import au.lupine.quarters.object.entity.Quarter;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -15,6 +16,7 @@ public class QuarterDeleteEvent extends QuartersEvent {
     private final CommandSender sender;
 
     public QuarterDeleteEvent(@NotNull Quarter quarter, @Nullable CommandSender sender) {
+        super(!Bukkit.isPrimaryThread());
         this.quarter = quarter;
         this.sender = sender;
     }

--- a/src/main/java/au/lupine/quarters/api/event/QuarterDeleteEvent.java
+++ b/src/main/java/au/lupine/quarters/api/event/QuarterDeleteEvent.java
@@ -1,0 +1,78 @@
+package au.lupine.quarters.api.event;
+
+import au.lupine.quarters.object.base.CancellableQuartersEvent;
+import au.lupine.quarters.object.entity.Quarter;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class QuarterDeleteEvent extends CancellableQuartersEvent {
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Quarter quarter;
+    private final Cause cause;
+    private final CommandSender sender;
+
+    public QuarterDeleteEvent(@NotNull Quarter quarter, @NotNull Cause cause, @Nullable CommandSender sender) {
+        this.quarter = quarter;
+        this.cause = cause;
+        this.sender = sender;
+    }
+
+    /**
+     * @return The deleted quarter.
+     */
+    @NotNull
+    public Quarter getQuarter() {
+        return quarter;
+    }
+
+    /**
+     * @return The {@link Cause cause} of the quarter's deletion.
+     */
+    @NotNull
+    public Cause getCause() {
+        return cause;
+    }
+
+    /**
+     * @return The {@link CommandSender sender} who caused the deletion.
+     */
+    @Nullable
+    public CommandSender getSender() {
+        return sender;
+    }
+
+    public enum Cause {
+        UNKNOWN,
+        /**
+         * The quarter was deleted for containing Wilderness.
+         */
+        CONTAINS_WILDERNESS,
+        /**
+         * The quarter was deleted because a player used /quarters delete.
+         */
+        COMMAND,
+        /**
+         * The quarter was deleted because an admin used /quartersadmin delete.
+         */
+        ADMIN_COMMAND;
+
+        @ApiStatus.Internal
+        public boolean ignoresCancellation() {
+            return this == CONTAINS_WILDERNESS;
+        }
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/au/lupine/quarters/command/quarters/method/DeleteArgument.java
+++ b/src/main/java/au/lupine/quarters/command/quarters/method/DeleteArgument.java
@@ -1,7 +1,7 @@
 package au.lupine.quarters.command.quarters.method;
 
 import au.lupine.quarters.api.QuartersMessaging;
-import au.lupine.quarters.api.event.QuarterDeleteEvent;
+import au.lupine.quarters.api.event.CancellableQuarterDeleteEvent;
 import au.lupine.quarters.command.quarters.method.delete.DeleteAllMethod;
 import au.lupine.quarters.command.quarters.method.delete.DeletePlotMethod;
 import au.lupine.quarters.object.base.CommandArgument;
@@ -48,8 +48,7 @@ public class DeleteArgument extends CommandArgument {
 
         if (!quarter.isPlayerInTown(player)) throw new CommandMethodException(StringConstants.THIS_QUARTER_IS_NOT_PART_OF_YOUR_TOWN);
 
-        boolean deleted = quarter.delete(QuarterDeleteEvent.Cause.COMMAND, player);
-        if (deleted) {
+        if (quarter.delete(CancellableQuarterDeleteEvent.Cause.DELETE_COMMAND, player)) {
             QuartersMessaging.sendSuccessMessage(player, StringConstants.SUCCESSFULLY_DELETED_THIS_QUARTER);
             QuartersMessaging.sendCommandFeedbackToTown(town, player, "has deleted a quarter", player.getLocation());
         }

--- a/src/main/java/au/lupine/quarters/command/quarters/method/DeleteArgument.java
+++ b/src/main/java/au/lupine/quarters/command/quarters/method/DeleteArgument.java
@@ -1,6 +1,7 @@
 package au.lupine.quarters.command.quarters.method;
 
 import au.lupine.quarters.api.QuartersMessaging;
+import au.lupine.quarters.api.event.QuarterDeleteEvent;
 import au.lupine.quarters.command.quarters.method.delete.DeleteAllMethod;
 import au.lupine.quarters.command.quarters.method.delete.DeletePlotMethod;
 import au.lupine.quarters.object.base.CommandArgument;
@@ -47,9 +48,10 @@ public class DeleteArgument extends CommandArgument {
 
         if (!quarter.isPlayerInTown(player)) throw new CommandMethodException(StringConstants.THIS_QUARTER_IS_NOT_PART_OF_YOUR_TOWN);
 
-        quarter.delete();
-
-        QuartersMessaging.sendSuccessMessage(player, StringConstants.SUCCESSFULLY_DELETED_THIS_QUARTER);
-        QuartersMessaging.sendCommandFeedbackToTown(town, player, "has deleted a quarter", player.getLocation());
+        boolean deleted = quarter.delete(QuarterDeleteEvent.Cause.COMMAND, player);
+        if (deleted) {
+            QuartersMessaging.sendSuccessMessage(player, StringConstants.SUCCESSFULLY_DELETED_THIS_QUARTER);
+            QuartersMessaging.sendCommandFeedbackToTown(town, player, "has deleted a quarter", player.getLocation());
+        }
     }
 }

--- a/src/main/java/au/lupine/quarters/command/quarters/method/delete/DeleteAllMethod.java
+++ b/src/main/java/au/lupine/quarters/command/quarters/method/delete/DeleteAllMethod.java
@@ -1,8 +1,10 @@
 package au.lupine.quarters.command.quarters.method.delete;
 
 import au.lupine.quarters.api.QuartersMessaging;
+import au.lupine.quarters.api.event.CancellableQuarterDeleteEvent;
 import au.lupine.quarters.api.manager.QuarterManager;
 import au.lupine.quarters.object.base.CommandMethod;
+import au.lupine.quarters.object.entity.Quarter;
 import au.lupine.quarters.object.exception.CommandMethodException;
 import au.lupine.quarters.object.wrapper.StringConstants;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -10,8 +12,6 @@ import com.palmergames.bukkit.towny.confirmations.Confirmation;
 import com.palmergames.bukkit.towny.object.Town;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public class DeleteAllMethod extends CommandMethod {
 
@@ -27,7 +27,10 @@ public class DeleteAllMethod extends CommandMethod {
         if (town == null) throw new CommandMethodException(StringConstants.YOU_ARE_NOT_PART_OF_A_TOWN);
 
         Confirmation.runOnAccept(() -> {
-            QuarterManager.getInstance().setQuarters(town, new CopyOnWriteArrayList<>());
+            for (Quarter quarter : QuarterManager.getInstance().getQuarters(town)) {
+                quarter.delete(CancellableQuarterDeleteEvent.Cause.DELETE_ALL_COMMAND, player);
+            }
+
             QuartersMessaging.sendSuccessMessage(player, "Successfully deleted all quarters in " + town.getName());
             QuartersMessaging.sendCommandFeedbackToTown(town, player, "has deleted all quarters in " + town.getName(), null);
         }).setTitle("Are you sure you want to delete all the quarters in " + town.getName() + "?")

--- a/src/main/java/au/lupine/quarters/command/quarters/method/delete/DeletePlotMethod.java
+++ b/src/main/java/au/lupine/quarters/command/quarters/method/delete/DeletePlotMethod.java
@@ -1,7 +1,7 @@
 package au.lupine.quarters.command.quarters.method.delete;
 
 import au.lupine.quarters.api.QuartersMessaging;
-import au.lupine.quarters.api.event.QuarterDeleteEvent;
+import au.lupine.quarters.api.event.CancellableQuarterDeleteEvent;
 import au.lupine.quarters.api.manager.QuarterManager;
 import au.lupine.quarters.object.base.CommandMethod;
 import au.lupine.quarters.object.entity.Quarter;
@@ -38,7 +38,7 @@ public class DeletePlotMethod extends CommandMethod {
 
         Confirmation.runOnAccept(() -> {
             for (Quarter quarter : quarters) {
-                quarter.delete(QuarterDeleteEvent.Cause.COMMAND, player);
+                quarter.delete(CancellableQuarterDeleteEvent.Cause.DELETE_PLOT_COMMAND, player);
             }
 
             QuartersMessaging.sendSuccessMessage(player, "Successfully deleted all quarters in this townblock");

--- a/src/main/java/au/lupine/quarters/command/quarters/method/delete/DeletePlotMethod.java
+++ b/src/main/java/au/lupine/quarters/command/quarters/method/delete/DeletePlotMethod.java
@@ -1,6 +1,7 @@
 package au.lupine.quarters.command.quarters.method.delete;
 
 import au.lupine.quarters.api.QuartersMessaging;
+import au.lupine.quarters.api.event.QuarterDeleteEvent;
 import au.lupine.quarters.api.manager.QuarterManager;
 import au.lupine.quarters.object.base.CommandMethod;
 import au.lupine.quarters.object.entity.Quarter;
@@ -37,7 +38,7 @@ public class DeletePlotMethod extends CommandMethod {
 
         Confirmation.runOnAccept(() -> {
             for (Quarter quarter : quarters) {
-                quarter.delete();
+                quarter.delete(QuarterDeleteEvent.Cause.COMMAND, player);
             }
 
             QuartersMessaging.sendSuccessMessage(player, "Successfully deleted all quarters in this townblock");

--- a/src/main/java/au/lupine/quarters/command/quartersadmin/method/AdminDeleteMethod.java
+++ b/src/main/java/au/lupine/quarters/command/quartersadmin/method/AdminDeleteMethod.java
@@ -1,7 +1,7 @@
 package au.lupine.quarters.command.quartersadmin.method;
 
 import au.lupine.quarters.api.QuartersMessaging;
-import au.lupine.quarters.api.event.QuarterDeleteEvent;
+import au.lupine.quarters.api.event.CancellableQuarterDeleteEvent;
 import au.lupine.quarters.object.base.CommandMethod;
 import au.lupine.quarters.object.entity.Quarter;
 import au.lupine.quarters.object.wrapper.StringConstants;
@@ -19,9 +19,6 @@ public class AdminDeleteMethod extends CommandMethod {
         Player player = getSenderAsPlayerOrThrow();
         Quarter quarter = getQuarterAtPlayerOrThrow(player);
 
-        boolean deleted = quarter.delete(QuarterDeleteEvent.Cause.ADMIN_COMMAND, player);
-        if (deleted) {
-            QuartersMessaging.sendSuccessMessage(player, StringConstants.SUCCESSFULLY_DELETED_THIS_QUARTER);
-        }
+        if (quarter.delete(CancellableQuarterDeleteEvent.Cause.ADMIN_DELETE_COMMAND, player)) QuartersMessaging.sendSuccessMessage(player, StringConstants.SUCCESSFULLY_DELETED_THIS_QUARTER);
     }
 }

--- a/src/main/java/au/lupine/quarters/command/quartersadmin/method/AdminDeleteMethod.java
+++ b/src/main/java/au/lupine/quarters/command/quartersadmin/method/AdminDeleteMethod.java
@@ -1,6 +1,7 @@
 package au.lupine.quarters.command.quartersadmin.method;
 
 import au.lupine.quarters.api.QuartersMessaging;
+import au.lupine.quarters.api.event.QuarterDeleteEvent;
 import au.lupine.quarters.object.base.CommandMethod;
 import au.lupine.quarters.object.entity.Quarter;
 import au.lupine.quarters.object.wrapper.StringConstants;
@@ -18,8 +19,9 @@ public class AdminDeleteMethod extends CommandMethod {
         Player player = getSenderAsPlayerOrThrow();
         Quarter quarter = getQuarterAtPlayerOrThrow(player);
 
-        quarter.delete();
-
-        QuartersMessaging.sendSuccessMessage(player, StringConstants.SUCCESSFULLY_DELETED_THIS_QUARTER);
+        boolean deleted = quarter.delete(QuarterDeleteEvent.Cause.ADMIN_COMMAND, player);
+        if (deleted) {
+            QuartersMessaging.sendSuccessMessage(player, StringConstants.SUCCESSFULLY_DELETED_THIS_QUARTER);
+        }
     }
 }

--- a/src/main/java/au/lupine/quarters/listener/QuarterIntegrityListener.java
+++ b/src/main/java/au/lupine/quarters/listener/QuarterIntegrityListener.java
@@ -1,6 +1,6 @@
 package au.lupine.quarters.listener;
 
-import au.lupine.quarters.api.event.QuarterDeleteEvent;
+import au.lupine.quarters.api.event.CancellableQuarterDeleteEvent;
 import au.lupine.quarters.api.manager.QuarterManager;
 import au.lupine.quarters.object.entity.Quarter;
 import com.palmergames.bukkit.towny.TownyMessaging;
@@ -40,7 +40,7 @@ public class QuarterIntegrityListener implements Listener {
         if (town == null) return;
 
         for (Quarter quarter : QuarterManager.getInstance().getQuarters(event.getWorldCoord())) {
-            quarter.delete(QuarterDeleteEvent.Cause.CONTAINS_WILDERNESS, null); // The quarter now contains wilderness and should not exist
+            quarter.delete(); // The quarter now contains wilderness and should not exist
         }
     }
 

--- a/src/main/java/au/lupine/quarters/listener/QuarterIntegrityListener.java
+++ b/src/main/java/au/lupine/quarters/listener/QuarterIntegrityListener.java
@@ -1,5 +1,6 @@
 package au.lupine.quarters.listener;
 
+import au.lupine.quarters.api.event.QuarterDeleteEvent;
 import au.lupine.quarters.api.manager.QuarterManager;
 import au.lupine.quarters.object.entity.Quarter;
 import com.palmergames.bukkit.towny.TownyMessaging;
@@ -39,7 +40,7 @@ public class QuarterIntegrityListener implements Listener {
         if (town == null) return;
 
         for (Quarter quarter : QuarterManager.getInstance().getQuarters(event.getWorldCoord())) {
-            quarter.delete(); // The quarter now contains wilderness and should not exist
+            quarter.delete(QuarterDeleteEvent.Cause.CONTAINS_WILDERNESS, null); // The quarter now contains wilderness and should not exist
         }
     }
 

--- a/src/main/java/au/lupine/quarters/object/base/CancellableQuartersEvent.java
+++ b/src/main/java/au/lupine/quarters/object/base/CancellableQuartersEvent.java
@@ -1,13 +1,12 @@
 package au.lupine.quarters.object.base;
 
-import org.bukkit.ChatColor;
 import org.bukkit.event.Cancellable;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class CancellableQuartersEvent extends QuartersEvent implements Cancellable {
 
     private boolean isCancelled;
-    private String cancelMessage = ChatColor.RED + "A plugin cancelled this event.";
+    private String cancelMessage = null;
 
     public CancellableQuartersEvent() {
         super();
@@ -17,12 +16,14 @@ public abstract class CancellableQuartersEvent extends QuartersEvent implements 
         super(isAsync);
     }
 
-    @NotNull
-    public String getCancelMessage() {
+    public @Nullable String getCancelMessage() {
         return cancelMessage;
     }
 
-    public void setCancelMessage(@NotNull String cancelMessage) {
+    /**
+     * If a cancel message is set, this can be used by the event but depends on the event's implementation
+     */
+    public void setCancelMessage(String cancelMessage) {
         this.cancelMessage = cancelMessage;
     }
 

--- a/src/main/java/au/lupine/quarters/object/base/CancellableQuartersEvent.java
+++ b/src/main/java/au/lupine/quarters/object/base/CancellableQuartersEvent.java
@@ -1,10 +1,13 @@
 package au.lupine.quarters.object.base;
 
+import org.bukkit.ChatColor;
 import org.bukkit.event.Cancellable;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class CancellableQuartersEvent extends QuartersEvent implements Cancellable {
 
     private boolean isCancelled;
+    private String cancelMessage = ChatColor.RED + "A plugin cancelled this event.";
 
     public CancellableQuartersEvent() {
         super();
@@ -12,6 +15,15 @@ public abstract class CancellableQuartersEvent extends QuartersEvent implements 
 
     public CancellableQuartersEvent(boolean isAsync) {
         super(isAsync);
+    }
+
+    @NotNull
+    public String getCancelMessage() {
+        return cancelMessage;
+    }
+
+    public void setCancelMessage(@NotNull String cancelMessage) {
+        this.cancelMessage = cancelMessage;
     }
 
     @Override

--- a/src/main/java/au/lupine/quarters/object/base/QuartersEvent.java
+++ b/src/main/java/au/lupine/quarters/object/base/QuartersEvent.java
@@ -1,12 +1,8 @@
 package au.lupine.quarters.object.base;
 
 import org.bukkit.event.Event;
-import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public abstract class QuartersEvent extends Event {
-
-    private static final HandlerList HANDLER_LIST = new HandlerList();
 
     public QuartersEvent() {
         super();
@@ -14,14 +10,5 @@ public abstract class QuartersEvent extends Event {
 
     public QuartersEvent(boolean isAsync) {
         super(isAsync);
-    }
-
-    public static HandlerList getHandlerList() {
-        return HANDLER_LIST;
-    }
-
-    @Override
-    public @NotNull HandlerList getHandlers() {
-        return HANDLER_LIST;
     }
 }

--- a/src/main/java/au/lupine/quarters/object/entity/Quarter.java
+++ b/src/main/java/au/lupine/quarters/object/entity/Quarter.java
@@ -2,6 +2,7 @@ package au.lupine.quarters.object.entity;
 
 import au.lupine.quarters.api.QuartersMessaging;
 import au.lupine.quarters.api.event.CancellableQuarterDeleteEvent;
+import au.lupine.quarters.api.event.QuarterDeleteEvent;
 import au.lupine.quarters.api.manager.*;
 import au.lupine.quarters.object.state.ActionType;
 import au.lupine.quarters.object.state.QuarterType;
@@ -91,6 +92,9 @@ public class Quarter extends TownyObject {
         quarters.add(this);
 
         qm.setQuarters(town, quarters);
+
+        QuarterDeleteEvent event = new QuarterDeleteEvent(this, null);
+        event.callEvent();
     }
 
     /**
@@ -110,15 +114,17 @@ public class Quarter extends TownyObject {
      * @return true if the quarter was successfully deleted, false if deletion was cancelled
      */
     public boolean delete(@NotNull CancellableQuarterDeleteEvent.Cause cause, @Nullable CommandSender sender) {
-        CancellableQuarterDeleteEvent event = new CancellableQuarterDeleteEvent(this, cause, sender);
+        CancellableQuarterDeleteEvent cqde = new CancellableQuarterDeleteEvent(this, cause, sender);
 
-        if (!event.callEvent()) {
-            String cancelMessage = event.getCancelMessage();
+        if (!cqde.callEvent()) {
+            String cancelMessage = cqde.getCancelMessage();
             if (sender != null && cancelMessage != null) QuartersMessaging.sendErrorMessage(sender, cancelMessage);
             return false;
         }
 
         delete();
+
+        new QuarterDeleteEvent(this, sender).callEvent();
 
         return true;
     }

--- a/src/main/java/au/lupine/quarters/object/entity/Quarter.java
+++ b/src/main/java/au/lupine/quarters/object/entity/Quarter.java
@@ -1,12 +1,12 @@
 package au.lupine.quarters.object.entity;
 
-import au.lupine.quarters.api.event.QuarterDeleteEvent;
+import au.lupine.quarters.api.QuartersMessaging;
+import au.lupine.quarters.api.event.CancellableQuarterDeleteEvent;
 import au.lupine.quarters.api.manager.*;
 import au.lupine.quarters.object.state.ActionType;
 import au.lupine.quarters.object.state.QuarterType;
 import au.lupine.quarters.object.wrapper.QuarterPermissions;
 import com.palmergames.bukkit.towny.TownyAPI;
-import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
@@ -94,7 +94,7 @@ public class Quarter extends TownyObject {
     }
 
     /**
-     * Permanently delete this quarter from the town's metadata
+     * Permanently and forcefully delete this quarter from the town's metadata
      */
     public void delete() {
         QuarterManager qm = QuarterManager.getInstance();
@@ -106,24 +106,20 @@ public class Quarter extends TownyObject {
     }
 
     /**
-     * Permanently delete this quarter from the town's metadata, with a cause and optional sender.
-     * @return true if the quarter was successfully deleted, false if deletion was cancelled.
+     * Permanently delete this quarter from the town's metadata, with a cause and optional sender
+     * @return true if the quarter was successfully deleted, false if deletion was cancelled
      */
-    public boolean delete(@NotNull QuarterDeleteEvent.Cause cause, @Nullable CommandSender sender) {
-        QuarterDeleteEvent event = new QuarterDeleteEvent(this, cause, sender);
-        if (!event.callEvent() && cause.ignoresCancellation()) {
-            if (sender != null) {
-                TownyMessaging.sendErrorMsg(sender, event.getCancelMessage());
-            }
+    public boolean delete(@NotNull CancellableQuarterDeleteEvent.Cause cause, @Nullable CommandSender sender) {
+        CancellableQuarterDeleteEvent event = new CancellableQuarterDeleteEvent(this, cause, sender);
+
+        if (!event.callEvent()) {
+            String cancelMessage = event.getCancelMessage();
+            if (sender != null && cancelMessage != null) QuartersMessaging.sendErrorMessage(sender, cancelMessage);
             return false;
         }
 
-        QuarterManager qm = QuarterManager.getInstance();
+        delete();
 
-        List<Quarter> quarters = qm.getQuarters(town);
-        quarters.remove(this);
-
-        qm.setQuarters(town, quarters);
         return true;
     }
 

--- a/src/main/java/au/lupine/quarters/object/entity/Quarter.java
+++ b/src/main/java/au/lupine/quarters/object/entity/Quarter.java
@@ -1,16 +1,19 @@
 package au.lupine.quarters.object.entity;
 
+import au.lupine.quarters.api.event.QuarterDeleteEvent;
 import au.lupine.quarters.api.manager.*;
 import au.lupine.quarters.object.state.ActionType;
 import au.lupine.quarters.object.state.QuarterType;
 import au.lupine.quarters.object.wrapper.QuarterPermissions;
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownyObject;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.ApiStatus;
@@ -100,6 +103,28 @@ public class Quarter extends TownyObject {
         quarters.remove(this);
 
         qm.setQuarters(town, quarters);
+    }
+
+    /**
+     * Permanently delete this quarter from the town's metadata, with a cause and optional sender.
+     * @return true if the quarter was successfully deleted, false if deletion was cancelled.
+     */
+    public boolean delete(@NotNull QuarterDeleteEvent.Cause cause, @Nullable CommandSender sender) {
+        QuarterDeleteEvent event = new QuarterDeleteEvent(this, cause, sender);
+        if (!event.callEvent() && cause.ignoresCancellation()) {
+            if (sender != null) {
+                TownyMessaging.sendErrorMsg(sender, event.getCancelMessage());
+            }
+            return false;
+        }
+
+        QuarterManager qm = QuarterManager.getInstance();
+
+        List<Quarter> quarters = qm.getQuarters(town);
+        quarters.remove(this);
+
+        qm.setQuarters(town, quarters);
+        return true;
     }
 
     /**


### PR DESCRIPTION
This PR adds a cancellable `QuarterDeleteEvent` which is fired when a quarter is deleted. The event is fired with a `Cause` so that plugins can see the deletion reason. If the event is cancelled, a message is sent to the deleting player if one exists. Quarters will be deleted regardless of the event's cancellation state if the `Cause` is `Cause.CONTAINS_WILDERNESS`.

I have kept the original deletion method since I am unsure what to do with it. All of its internal uses have been replaced with a new deletion method which fires this event. 