### PR TITLE
Fix entry listener memory leak

### DIFF
--- a/src/main/java/au/lupine/quarters/listener/QuarterEntryListener.java
+++ b/src/main/java/au/lupine/quarters/listener/QuarterEntryListener.java
@@ -20,11 +20,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -32,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class QuarterEntryListener implements Listener {
 
-    private static final Map<Player, Optional<Quarter>> QUARTER_PLAYER_IS_IN = new ConcurrentHashMap<>();
+    private static final Map<UUID, Quarter> QUARTER_PLAYER_IS_IN = new ConcurrentHashMap<>();
 
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
@@ -47,10 +48,11 @@ public class QuarterEntryListener implements Listener {
 
         Quarter quarter = QuarterManager.getInstance().getQuarter(to);
 
-        Optional<Quarter> previousQuarter = QUARTER_PLAYER_IS_IN.get(player);
-        if (quarter != null && (previousQuarter.isEmpty() || !previousQuarter.get().equals(quarter))) onQuarterEntry(quarter, resident);
+        Quarter previousQuarter = QUARTER_PLAYER_IS_IN.get(player.getUniqueId());
+        if (quarter != null && (previousQuarter == null || !previousQuarter.equals(quarter)))
+            onQuarterEntry(quarter, resident);
 
-        QUARTER_PLAYER_IS_IN.put(player, Optional.ofNullable(quarter));
+        QUARTER_PLAYER_IS_IN.put(player.getUniqueId(), quarter);
     }
 
     @EventHandler
@@ -61,7 +63,7 @@ public class QuarterEntryListener implements Listener {
 
         Quarter quarter = QuarterManager.getInstance().getQuarter(player.getLocation());
 
-        QUARTER_PLAYER_IS_IN.put(player, Optional.ofNullable(quarter));
+        QUARTER_PLAYER_IS_IN.put(player.getUniqueId(), quarter);
     }
 
     private void onQuarterEntry(Quarter quarter, Resident resident) {
@@ -107,5 +109,10 @@ public class QuarterEntryListener implements Listener {
             case ACTION_BAR -> player.sendActionBar(notification);
             case CHAT -> QuartersMessaging.sendMessage(player, notification);
         }
+    }
+
+    @EventHandler
+    public void cleanupCachedQuarter(final PlayerQuitEvent event) {
+        QUARTER_PLAYER_IS_IN.remove(event.getPlayer().getUniqueId());
     }
 }


### PR DESCRIPTION
Removes players from the cache map in the entry listener class to fix a leak, and removes the optional since it's not really needed in this case.