### PR TITLE
Add QuarterEntryNotificationEvent

### DIFF
--- a/src/main/java/au/lupine/quarters/api/event/QuarterEntryNotificationEvent.java
+++ b/src/main/java/au/lupine/quarters/api/event/QuarterEntryNotificationEvent.java
@@ -1,0 +1,49 @@
+package au.lupine.quarters.api.event;
+
+import au.lupine.quarters.object.entity.Quarter;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class QuarterEntryNotificationEvent extends Event {
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final Player player;
+    private final Quarter quarter;
+    private List<Component> messageComponents;
+
+    public QuarterEntryNotificationEvent(@NotNull Player player, @NotNull Quarter quarter, @NotNull List<Component> messageComponents) {
+        this.player = player;
+        this.quarter = quarter;
+        this.messageComponents = messageComponents;
+    }
+
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+
+    public @NotNull Quarter getQuarter() {
+        return quarter;
+    }
+
+    public List<Component> getMessageComponents() {
+        return messageComponents;
+    }
+
+    public void setMessageComponents(@NotNull List<Component> messageComponents) {
+        this.messageComponents = messageComponents;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/au/lupine/quarters/listener/QuarterEntryListener.java
+++ b/src/main/java/au/lupine/quarters/listener/QuarterEntryListener.java
@@ -1,6 +1,7 @@
 package au.lupine.quarters.listener;
 
 import au.lupine.quarters.api.QuartersMessaging;
+import au.lupine.quarters.api.event.QuarterEntryNotificationEvent;
 import au.lupine.quarters.api.manager.ConfigManager;
 import au.lupine.quarters.api.manager.QuarterManager;
 import au.lupine.quarters.api.manager.ResidentMetadataManager;
@@ -99,13 +100,17 @@ public class QuarterEntryListener implements Listener {
             components.add(price);
         }
 
+        Player player = resident.getPlayer();
+        if (player == null) return;
+
+        QuarterEntryNotificationEvent event = new QuarterEntryNotificationEvent(player, quarter, components);
+        event.callEvent();
+        components = event.getMessageComponents();
+
         JoinConfiguration jc = JoinConfiguration.separator(Component.text(" - ", TextColor.color(QuartersMessaging.PLUGIN_COLOUR.getRGB())));
         Component notification = Component.join(jc, components);
 
         EntryNotificationType notificationType = ResidentMetadataManager.getInstance().getEntryNotificationType(resident);
-
-        Player player = resident.getPlayer();
-        if (player == null) return;
 
         switch (notificationType) {
             case ACTION_BAR -> player.sendActionBar(notification);


### PR DESCRIPTION
Adds `QuarterEntryNotificationEvent`, which fires when the quarter entry notification is sent to a player. The event exposes the notification's message components, allowing plugins to modify them (e.g., to add extra information). 